### PR TITLE
Add support for mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,39 +9,105 @@ and name or excluded keys.
 
 ## Configuration
 
-By default, plugin will localize source `.yml` files,
+By default, plugin will localize source `.yml` and `.yaml` files,
 e.g. `/project/en.yml`,  and write localized file
-to a separate folder: `/project/<localeName>/en.yml`.
+to a subfolder: `/project/resources/ru-RU/en.yml`.
 
-This behavior can be changed by providing schema file, which should
-be named `<sourceFileName>-schema.json` and be placed in the same
-directory as the source file.
+The plugin will look for the `yaml` property within the `settings`
+of your `project.json` file. The following settings are
+used within the json property:
+
+- mappings: a mapping between file matchers and an object that gives
+  info used to localize the files that match it. This allows different
+  json files within the project to be processed with different schema.
+  The matchers are
+  a [micromatch-style string](https://www.npmjs.com/package/micromatch),
+  similar to the the `includes` and `excludes` section of a
+  `project.json` file. The value of that mapping is an object that
+  can contain the following properties:
+  - schema: schema file to use with that matcher. See more information
+    about schema files below.
+  - template: a path template to use to generate the path to
+    the translated output files. The template replaces strings
+    in square brackets with special values, and keeps any characters
+    intact that are not in square brackets. The default template,
+    if not specified is "resources/[localeDir]/[filename]".
+    The plugin recognizes and replaces the following strings
+    in template strings:
+    - [dir] the original directory where the matched source file
+      came from. This is given as a directory that is relative
+      to the root of the project. eg. "foo/bar/strings.json" -> "foo/bar"
+    - [filename] the file name of the matching file.
+      eg. "foo/bar/strings.json" -> "strings.json"
+    - [basename] the basename of the matching file without any extension
+      eg. "foo/bar/strings.json" -> "strings"
+    - [extension] the extension part of the file name of the source file.
+      etc. "foo/bar/strings.json" -> "json"
+    - [locale] the full BCP-47 locale specification for the target locale
+      eg. "zh-Hans-CN" -> "zh-Hans-CN"
+    - [language] the language portion of the full locale
+      eg. "zh-Hans-CN" -> "zh"
+    - [script] the script portion of the full locale
+      eg. "zh-Hans-CN" -> "Hans"
+    - [region] the region portion of the full locale
+      eg. "zh-Hans-CN" -> "CN"
+    - [localeDir] the full locale where each portion of the locale
+      is a directory in this order: [langage], [script], [region].
+      eg, "zh-Hans-CN" -> "zh/Hans/CN", but "en" -> "en".
+    - [localeUnder] the full BCP-47 locale specification, but using
+      underscores to separate the locale parts instead of dashes.
+      eg. "zh-Hans-CN" -> "zh_Hans_CN"
+
+Example configuration:
+```json
+{
+  "settings": {
+    "yaml": {
+      "mappings": {
+        "**/source.yml": {
+          "template": "resources/[localeDir]/source.yaml"
+        },
+        "src/**/strings.yaml": {
+          "schema": "strings-schema.json",
+          "template": "[dir]/strings.[locale].yaml"
+        }
+      }
+    }
+  }
+}
+```
+
+In the above example, any file named `souce.yml` will be parsed.
+The output files are saved to the `resources` directory.
+
+Also files named `strings.yaml` that are located in directory `src`
+or any of its subdirectories will be parsed using configuration from
+`string-schema.json`
 
 ## Schema file
 
-Example of `*-schema.json` file:
+Schema file is a `.json` file that alternates default behavior of
+yaml parser. In the schema file the following configration options
+may be provided:
+
+- `excluded_keys` - an array of keys that must be excluded from a
+  ResultSet of the parsing. It only allows the direct key exclusion, i.e.
+  a sequence of keys can not be used.
+- `comment_prefix` - a string that defines prefix for context comment for
+  translators. Only comments that start with the provided string will
+  be extracted and added to ResultSet, all other are ignored.
+
+Example of schema file:
 ```json
 {
-  "useLocalizedDirectories": false,
-  
   "excluded_keys": [
     "testKey",
     "anotherExcludedKey"
   ],
   
-  "outputFilenameMapping": {
-    "ru-RU": "/project/translations/ru.yml"
-  }
+  "comment_prefix": "L10N:" 
 }
 ```
-
-`useLocalizedDirectories` - specifies whether localized file should
-be placed in a separate directory. Default: `true`
-
-`excluded_keys` - array of keys to be excluded from localization
-
-`outputFilenameMapping` - array of mappings that
-specify output path for a locale: `<localeName>: <path`
 
 ## Providing context comments
 
@@ -88,6 +154,12 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.3.0
+- Add support for mappings in yaml config that allows custom output
+file naming and use of schema per-mapping
+- Add `comment_prefix` key to the schema that allows to specify prefix
+for context comments that are extracted along with source strings
 
 ### v1.2.0
 - Add support of yaml comments that enables providing context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-yaml",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "main": "./YamlFileType.js",
     "description": "A loctool plugin that knows how to process yaml files",
     "license": "Apache-2.0",

--- a/test/testYamlFileType.js
+++ b/test/testYamlFileType.js
@@ -26,14 +26,27 @@ var path = require("path");
 
 var p = new CustomProject({
     sourceLocale: "en-US",
-    resourceDirs: {
-        "yml": "config/locales"
-    },
     plugins: [
         path.join(process.cwd(), "YamlFileType")
     ]
 }, "./test/testfiles", {
-    locales:["en-GB"]
+    locales:["en-GB"],
+    yaml: {
+        mappings: {
+            "foo.yml": {
+                template: "resources/[locale]/foo.yml"
+            },
+            "**/strings.yaml": {
+                template: "[dir]/strings.[locale].yaml"
+            },
+            "**/test/strings.y?(a)ml": {
+                template: "[dir]/[basename]/[locale].[extension]"
+            },
+            "**/*.y?(a)ml": {
+                template: "resources/[locale]/[filename]"
+            }
+        }
+    }
 });
 
 var p2 = new CustomProject({
@@ -68,6 +81,17 @@ module.exports.yamlfiletype = {
         test.done();
     },
 
+    testYamlFileTypeHandlesYaml: function(test) {
+        test.expect(2);
+
+        var yft = new YamlFileType(p);
+        test.ok(yft);
+
+        test.ok(yft.handles("foo.yaml"));
+
+        test.done();
+    },
+
     testYamlFileTypeHandlesAnythingFalse: function(test) {
         test.expect(4);
 
@@ -87,110 +111,65 @@ module.exports.yamlfiletype = {
         var yft = new YamlFileType(p);
         test.ok(yft);
 
-        test.ok(!yft.handles("config/locales/en-US.yml"));
+        test.ok(!yft.handles("resources/ru-RU/foo.yml"));
 
         test.done();
     },
 
-    testYamlFileTypeHandlesNoFilesNamedForALocale: function(test) {
+    testYamlFileTypeHandlesSourceLocaleFilesInSubfolders: function(test) {
+        test.expect(2);
+
+        var yft = new YamlFileType(p);
+        test.ok(yft);
+
+        test.ok(yft.handles("subfolder/strings.en-US.yaml"));
+
+        test.done();
+    },
+
+    testYamlFileTypeHandlesNoLocalizedFilesInSubfolders: function(test) {
+        test.expect(2);
+
+        var yft = new YamlFileType(p);
+        test.ok(yft);
+
+        test.ok(!yft.handles("subfolder/strings.ru-RU.yaml"));
+
+        test.done();
+    },
+
+    testYamlFileTypeHandlesFilesNamedForALocale: function(test) {
         test.expect(4);
 
         var yft = new YamlFileType(p);
         test.ok(yft);
 
-        test.ok(!yft.handles("en-US.yml"));
-        test.ok(!yft.handles("de-DE.yml"));
-        test.ok(!yft.handles("en.yml"));
+        test.ok(yft.handles("en-US.yml"));
+        test.ok(yft.handles("de-DE.yml"));
+        test.ok(yft.handles("en.yml"));
 
         test.done();
     },
 
-    testYamlFileTypeHandlesNoFilesNamedForALocaleWithFlavor: function(test) {
-        test.expect(2);
-
-        var yft = new YamlFileType(p2);
-        test.ok(yft);
-
-        test.ok(!yft.handles("en-ZA-ASDF.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesNoFilesNamedForALocaleInASubdir: function(test) {
-        test.expect(4);
-
-        var yft = new YamlFileType(p);
-        test.ok(yft);
-
-        test.ok(!yft.handles("a/b/en-US.yml"));
-        test.ok(!yft.handles("c/d/de-DE.yml"));
-        test.ok(!yft.handles("e/f/en.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesNoFilesNamedForALocaleWithFlavorInASubdir: function(test) {
-        test.expect(2);
-
-        var yft = new YamlFileType(p2);
-        test.ok(yft);
-
-        test.ok(!yft.handles("a/b/en-ZA-ASDF.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesFilesAlmostNamedForALocale: function(test) {
+    testYamlFileTypeHandlesResourceFilesInSubdirs: function(test) {
         test.expect(2);
 
         var yft = new YamlFileType(p);
         test.ok(yft);
 
-        test.ok(yft.handles("config/states.yml"));
+        test.ok(yft.handles("resources/ru-RU/subdir/foo.yml"));
 
         test.done();
     },
 
-    testYamlFileTypeHandlesNoResourceFilesInSubdirs: function(test) {
-        test.expect(2);
+    testYamlFileTypeHandlesBasenameDirMapping: function(test) {
+        test.expect(3);
 
         var yft = new YamlFileType(p);
         test.ok(yft);
 
-        test.ok(!yft.handles("config/locales/auto/en-US.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesNoResourceFilesInSubdirsWithFlavors: function(test) {
-        test.expect(2);
-
-        var yft = new YamlFileType(p2);
-        test.ok(yft);
-
-        test.ok(!yft.handles("config/locales/auto/en-ZA-ASDF.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesNoBaseResourceFiles: function(test) {
-        test.expect(2);
-
-        var yft = new YamlFileType(p);
-        test.ok(yft);
-
-        test.ok(!yft.handles("config/locales/en.yml"));
-
-        test.done();
-    },
-
-    testYamlFileTypeHandlesIncludeFiles: function(test) {
-        test.expect(2);
-
-        var yft = new YamlFileType(p);
-        test.ok(yft);
-
-        test.ok(yft.handles("config/nofications.yml"));
+        test.ok(yft.handles("test/strings.yaml"));
+        test.ok(!yft.handles("test/strings/ru-RU.yaml"));
 
         test.done();
     }

--- a/test/testfiles/test3-schema.json
+++ b/test/testfiles/test3-schema.json
@@ -1,3 +1,4 @@
 {
-  "excluded_keys": ["do_not_read_me"]
+  "excluded_keys": ["do_not_read_me"],
+  "comment_prefix": "L10N:"
 }

--- a/test/testfiles/test3.yml
+++ b/test/testfiles/test3.yml
@@ -1,6 +1,8 @@
 ---
 title:
   read_me:
+    # L10N: Comment with prefix
     a: good
   do_not_read_me:
+    # Comment without L10N prefix
     c: bad


### PR DESCRIPTION
The pull request consists of two features:
1. Adding mappings support to yaml plugin similar to other plugins (json, markdown)
2. Adding `comment_prefix` schema setting that allows to specify prefix for context comments that are extracted and sent to translators. This allows to differentiate dev-only comments and context comments in the source yaml files.