### PR TITLE
Add support for mapping with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,46 +2,92 @@
 
 Ilib loctool plugin to parse and localize YAML files.
 
-This plugin can parse and localize **.yml** files. Optionally,
-schema file can be provided to configure plugin's behavior
-for a given source file, such as localized file path
-and name or excluded keys.
-
 ## Configuration
 
-By default, plugin will localize source `.yml` files,
+By default, plugin will localize source `.yml` and `.yaml` files,
 e.g. `/project/en.yml`,  and write localized file
-to a separate folder: `/project/<localeName>/en.yml`.
+to a subfolder: `/project/resources/ru-RU/en.yml`.
 
-This behavior can be changed by providing schema file, which should
-be named `<sourceFileName>-schema.json` and be placed in the same
-directory as the source file.
+The plugin will look for the `yaml` property within the `settings`
+of your `project.json` file. The following settings are
+used within the yaml property:
 
-## Schema file
+- mappings: a mapping between file matchers and an object that gives
+  info used to localize the files that match it. This allows different
+  yaml files within the project to be processed with different schema.
+  The matchers are
+  a [micromatch-style string](https://www.npmjs.com/package/micromatch),
+  similar to the the `includes` and `excludes` section of a
+  `project.json` file. The value of that mapping is an object that
+  can contain the following properties:
+  - `template`: a path template to use to generate the path to
+    the translated output files. The template replaces strings
+    in square brackets with special values, and keeps any characters
+    intact that are not in square brackets. The default template,
+    if not specified is "resources/[localeDir]/[filename]".
+    The plugin recognizes and replaces the following strings
+    in template strings:
+    - [dir] the original directory where the matched source file
+      came from. This is given as a directory that is relative
+      to the root of the project. eg. "foo/bar/strings.yaml" -> "foo/bar"
+    - [filename] the file name of the matching file.
+      eg. "foo/bar/strings.yaml" -> "strings.yaml"
+    - [basename] the basename of the matching file without any extension
+      eg. "foo/bar/strings.yaml" -> "strings"
+    - [extension] the extension part of the file name of the source file.
+      etc. "foo/bar/strings.yaml" -> "yaml"
+    - [locale] the full BCP-47 locale specification for the target locale
+      eg. "zh-Hans-CN" -> "zh-Hans-CN"
+    - [language] the language portion of the full locale
+      eg. "zh-Hans-CN" -> "zh"
+    - [script] the script portion of the full locale
+      eg. "zh-Hans-CN" -> "Hans"
+    - [region] the region portion of the full locale
+      eg. "zh-Hans-CN" -> "CN"
+    - [localeDir] the full locale where each portion of the locale
+      is a directory in this order: [langage], [script], [region].
+      eg, "zh-Hans-CN" -> "zh/Hans/CN", but "en" -> "en".
+    - [localeUnder] the full BCP-47 locale specification, but using
+      underscores to separate the locale parts instead of dashes.
+      eg. "zh-Hans-CN" -> "zh_Hans_CN"
+  - `excludedKeys` - an array of keys that must be excluded from a
+    ResultSet. Excluded key will also affect all its children
+    and ignore them too. It only allows the direct key exclusion,
+    i.e. a sequence of keys can not be used.
+  - `commentPrefix` - a string that defines prefix for context comment for
+    translators. Only comments that start with the provided string will
+    be extracted and added to ResultSet, all other are ignored.
 
-Example of `*-schema.json` file:
+Example configuration:
 ```json
 {
-  "useLocalizedDirectories": false,
-  
-  "excluded_keys": [
-    "testKey",
-    "anotherExcludedKey"
-  ],
-  
-  "outputFilenameMapping": {
-    "ru-RU": "/project/translations/ru.yml"
+  "settings": {
+    "yaml": {
+      "mappings": {
+        "**/source.yml": {
+          "template": "resources/[localeDir]/source.yaml"
+        },
+        "src/**/strings.yaml": {
+          "template": "[dir]/strings.[locale].yaml",
+          "excludedKeys": [
+            "one",
+            "another",
+            "test"
+          ],
+          "commentPrefix": "L10N:"
+        }
+      }
+    }
   }
 }
 ```
 
-`useLocalizedDirectories` - specifies whether localized file should
-be placed in a separate directory. Default: `true`
+In the above example, any file named `souce.yml` will be parsed.
+The output files are saved to the `resources` directory.
 
-`excluded_keys` - array of keys to be excluded from localization
-
-`outputFilenameMapping` - array of mappings that
-specify output path for a locale: `<localeName>: <path`
+Also files named `strings.yaml` that are located in directory `src`
+or any of its subdirectories will be parsed using specified `excludedKeys`
+and `commentPrefix` rules.
 
 ## Providing context comments
 
@@ -82,12 +128,58 @@ first line and at the end of the last is trimmed):
 would be parsed as
 `Multiline comment\n    with some extra spaces in between`
 
+## Legacy setup
+**Important: automatic schema files lookup is disabled once `mappings`
+section is specified in the `project.json`! Use configration parameters
+in a mapping as described above.**
+
+Prior mappings introduction that happened in v1.3.0 the plugin behavior
+was configurable via `*-schema.json` files.
+
+For each source file plugin will search for a schema file named
+`<sourceFileName>-schema.json` in the same dirctory the source
+file is located.
+
+### Schema file
+
+Example of `*-schema.json` file:
+```json
+{
+  "useLocalizedDirectories": false,
+  
+  "excluded_keys": [
+    "testKey",
+    "anotherExcludedKey"
+  ],
+  
+  "outputFilenameMapping": {
+    "ru-RU": "/project/translations/ru.yml"
+  }
+}
+```
+
+`useLocalizedDirectories` - specifies whether localized file should
+be placed in a separate directory. Default: `true`
+
+`excluded_keys` - array of keys to be excluded from localization
+(in `v1.3.0` this key was changed to `excludedKeys`, nevertheless the
+original key with an underscore is still supported even in mappings)
+
+`outputFilenameMapping` - array of mappings that
+specify output path for a locale: `<localeName>: <path`
+
 ## License
 
 This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.3.0
+- Add support for mappings in yaml config that allows custom output
+file naming and use of schema per-mapping
+- Add `commentPrefix` key to the schema that allows to specify prefix
+for context comments that are extracted along with source strings
 
 ### v1.2.0
 - Add support of yaml comments that enables providing context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-yaml",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "main": "./YamlFileType.js",
     "description": "A loctool plugin that knows how to process yaml files",
     "license": "Apache-2.0",

--- a/test/testfiles/test3.yml
+++ b/test/testfiles/test3.yml
@@ -1,6 +1,9 @@
 ---
 title:
   read_me:
+    #L10N: Comment with prefix
     a: good
   do_not_read_me:
+    # Comment without prefix
+    b: good too
     c: bad


### PR DESCRIPTION
The pull request consists of two features:

1. Adding mappings support to yaml plugin similar to other plugins (json, markdown)
2. Adding comment_prefix schema setting that allows to specify prefix for context comments that are extracted and sent to translators. This allows to differentiate dev-only comments and context comments in the source yaml files.

The changes are backward compatible with legacy schema files, see suggestion in: #6 