### PR TITLE
Update version number to v1.4.0 and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,17 @@ file for more details.
 
 ## Release Notes
 
+### v1.4.0
+
+- Add a hash of the file name into the key for each resource so that
+resource "a" from file1 does not conflict with resource "a" in file2.
+- Minimum version of node that this can run on is now v10
+
 ### v1.3.0
 - Add support for mappings in yaml config that allows custom output
 file naming and use of schema per-mapping
 - Add `commentPrefix` key to the schema that allows to specify prefix
 for context comments that are extracted along with source strings
-- Add the file name into the context for each resource so that resource
-"a" from file1 does not conflict with resource "a" in file2.
-- Minimum version of node that this can run on is now v10
 
 ### v1.2.0
 - Add support of yaml comments that enables providing context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-yaml",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "./YamlFileType.js",
     "description": "A loctool plugin that knows how to process yaml files",
     "license": "Apache-2.0",
@@ -46,7 +46,7 @@
         "clean": "git clean -f -d *"
     },
     "engines": {
-        "node": ">=6.0"
+        "node": ">=10.0"
     },
     "dependencies": {
         "ilib": "^14.12.0",


### PR DESCRIPTION
- Version v1.3.0 was already published. I forgot to put the tag
so I thought v1.2.0 was the last version. When I checked on npm
it looks like v1.3.0 was already there.
- Changed the "engine" setting in the package.json
- no code changes