### PR TITLE
Make isTranslatable check conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The plugin will look for the `yaml` property within the `settings`
 of your `project.json` file. The following settings are
 used within the yaml property:
 
-- mappings: a mapping between file matchers and an object that gives
+- `mappings`: a mapping between file matchers and an object that gives
   info used to localize the files that match it. This allows different
   yaml files within the project to be processed with different schema.
   The matchers are
@@ -57,6 +57,7 @@ used within the yaml property:
   - `commentPrefix` - a string that defines prefix for context comment for
     translators. Only comments that start with the provided string will
     be extracted and added to ResultSet, all other are ignored.
+- `checkTranslatability`: by default the plugin checks if lines in yaml file are translatable, to turn that check off `checkTranslatability` setting has to set to false.         
 
 Example configuration:
 ```json

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ used within the yaml property:
   - `commentPrefix` - a string that defines prefix for context comment for
     translators. Only comments that start with the provided string will
     be extracted and added to ResultSet, all other are ignored.
-- `checkTranslatability`: by default the plugin checks if lines in yaml file are translatable, to turn that check off `checkTranslatability` setting has to set to false.         
+- `checkTranslatability`: by default, the plugin tries to guess which values
+  in the file are strings for translation and filter out others;
+  setting `checkTranslatablility`: false will disable this behaviour and all
+  values from the file will be extracted.
 
 Example configuration:
 ```json

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -142,10 +142,10 @@ var badEndPunct = {
 YamlFile.prototype._isTranslatable = function(resource) {
     var locale = new Locale(this.getLocale());
 
-    var yamlSettings = this.project.settings.yaml;
+    // var yamlSettings = this.project.settings.yaml;
 
-    // if extra config exists in yaml settings (project.json) and checkNonTranslatable is set to false then check will be skipped
-    if ((yamlSettings.config) && !(yamlSettings.config.checkNonTranslatable)) return true;
+    // if checkTranslatability setting exists in the yaml property and it's set to false then check will be turned off
+    if (yamlSettings && (yamlSettings.checkTranslatability === false)) return true;
 
     if (!resource || typeof(resource) !== "string") {
         return false;

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -142,7 +142,7 @@ var badEndPunct = {
 YamlFile.prototype._isTranslatable = function(resource) {
     var locale = new Locale(this.getLocale());
 
-    var yamlSettings = this.project.settings.yaml;
+    var yamlSettings = this.project.settings && this.project.settings.yaml;
 
     // if checkTranslatability setting exists in the yaml property and it's set to false then check will be turned off
     if (yamlSettings && (yamlSettings.checkTranslatability === false)) return true;

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -142,7 +142,7 @@ var badEndPunct = {
 YamlFile.prototype._isTranslatable = function(resource) {
     var locale = new Locale(this.getLocale());
 
-    // var yamlSettings = this.project.settings.yaml;
+    var yamlSettings = this.project.settings.yaml;
 
     // if checkTranslatability setting exists in the yaml property and it's set to false then check will be turned off
     if (yamlSettings && (yamlSettings.checkTranslatability === false)) return true;

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -142,6 +142,11 @@ var badEndPunct = {
 YamlFile.prototype._isTranslatable = function(resource) {
     var locale = new Locale(this.getLocale());
 
+    var yamlSettings = this.project.settings.yaml;
+
+    // if extra config exists in yaml settings (project.json) and checkNonTranslatable is set to false then check will be skipped
+    if ((yamlSettings.config) && !(yamlSettings.config.checkNonTranslatable)) return true;
+
     if (!resource || typeof(resource) !== "string") {
         return false;
     }


### PR DESCRIPTION
In this PR the logic to turn off translatability check has been added. That check can be turned off using `checkTranslatability` setting set to false in the `yaml` property (project.json file). By default translatability check is turned on. 

Changes have been tested locally with BoxShuttle project. 

TO DO once this PR is merged:

- [x] add checkTranslatability setting set to false in [BoxShuttle/project.json.template](https://git.dev.box.net/moji/l10n-tools/tree/master/PushPullJobs/ProjectsConfig/BoxShuttle) (https://git.dev.box.net/moji/l10n-tools/pull/291)
- [x] remove workaround [branch](https://git.dev.box.net/moji/l10n-tools/tree/workaround-box-shuttle) in l10n-tools
- [x] remove workaround [branch](https://github.com/iLib-js/ilib-loctool-yaml/tree/workaround-translatable) in ilib-loctool-yaml